### PR TITLE
Make crate no_std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "passively-maintained" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.8"
+rand = { version = "0.8", default-features = false }
 
 [target.'cfg(not(windows))'.dev-dependencies]
 pprof = { version = "0.10", features = ["flamegraph"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,10 @@
 //! assert!((0.0..1.0).contains(&rn));
 //! ```
 //!
-use std::cmp::min;
+//! This crate is `no_std` compatible.
+//!
+#![no_std]
+use core::cmp::min;
 
 use rand::{Error, RngCore, SeedableRng};
 

--- a/src/tinymt32.rs
+++ b/src/tinymt32.rs
@@ -1,4 +1,4 @@
-use std::cmp::min;
+use core::cmp::min;
 
 use crate::TinyMT32;
 

--- a/src/tinymt64.rs
+++ b/src/tinymt64.rs
@@ -1,4 +1,4 @@
-use std::cmp::min;
+use core::cmp::min;
 
 use crate::TinyMT64;
 


### PR DESCRIPTION
`no_std` is used for constrained platforms, such as microcontrollers. As TinyMT is a particularly small and efficient random number generator, making it easily usable on such platforms is a good thing.

The changes required to make this crate compatible to `no_std` were fairly small and do not affect `std` users:

- If a user wants to use the `std` features of the dependency `rand`, feature unification will cause `rand` to be built with the `std` feature without any issues.

- This crate (TinyMT) does not use any non-core features, so it is not impacted directly by `#![no_std]`.